### PR TITLE
AsyncTaskCodeActivity now recreates its CancellationTokenSource.

### DIFF
--- a/Community.Activities.sln
+++ b/Community.Activities.sln
@@ -40,8 +40,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UiPath.FTP.Activities", "FT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UiPath.FTP.Activities.Design", "FTP\UiPath.FTP.Activities.Design\UiPath.FTP.Activities.Design.csproj", "{7D1DC1A6-AA81-4E6A-9081-97BF21662F4E}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{4B6FEFA2-F51E-4577-858E-320B8A094289}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "UiPath.Shared.Activities", "Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.shproj", "{4E20C041-2F59-408E-ADB3-0BCFAB48DE61}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{4e20c041-2f59-408e-adb3-0bcfab48de61}*SharedItemsImports = 13
 		Shared\UiPath.Shared.Activities\UiPath.Shared.Activities.projitems*{fdfc92ee-090c-4e23-9422-f90eb94c43dd}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -155,6 +160,7 @@ Global
 		{E9137637-B657-4C22-85A5-2E30ADF82566} = {099CA148-FA0A-44E4-8C8A-CAF7B106897E}
 		{FDFC92EE-090C-4E23-9422-F90EB94C43DD} = {099CA148-FA0A-44E4-8C8A-CAF7B106897E}
 		{7D1DC1A6-AA81-4E6A-9081-97BF21662F4E} = {099CA148-FA0A-44E4-8C8A-CAF7B106897E}
+		{4E20C041-2F59-408E-ADB3-0BCFAB48DE61} = {4B6FEFA2-F51E-4577-858E-320B8A094289}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {80E44DEF-976F-46BF-9DD8-F07334768E20}

--- a/FTP/FTPAssemblyInfo.cs
+++ b/FTP/FTPAssemblyInfo.cs
@@ -14,5 +14,5 @@ using System.Windows.Markup;
 [assembly: XmlnsDefinition("http://schemas.uipath.com/workflow/activities/ftp", "UiPath.FTP.Activities")]
 [assembly: XmlnsDefinition("http://schemas.uipath.com/workflow/activities/ftp", "UiPath.FTP.Activities.Design")]
 
-[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyVersion("2.0.1")]
 

--- a/Shared/UiPath.Shared.Activities/AsyncTaskCodeActivity.cs
+++ b/Shared/UiPath.Shared.Activities/AsyncTaskCodeActivity.cs
@@ -8,7 +8,7 @@ namespace UiPath.Shared.Activities
 {
     public abstract class AsyncTaskCodeActivity : AsyncCodeActivity, IDisposable
     {
-        private CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private CancellationTokenSource _cancellationTokenSource;
         private bool _tokenDisposed = false;
 
         protected override void Cancel(AsyncCodeActivityContext context)
@@ -31,6 +31,14 @@ namespace UiPath.Shared.Activities
 
         protected sealed override IAsyncResult BeginExecute(AsyncCodeActivityContext context, AsyncCallback callback, object state)
         {
+            if (!_tokenDisposed)
+            {
+                _cancellationTokenSource?.Dispose();
+            }
+
+            _cancellationTokenSource = new CancellationTokenSource();
+            _tokenDisposed = false;
+
             TaskCompletionSource<Action<AsyncCodeActivityContext>> taskCompletionSource = new TaskCompletionSource<Action<AsyncCodeActivityContext>>(state);
             Task<Action<AsyncCodeActivityContext>> task = ExecuteAsync(context, _cancellationTokenSource.Token);
 

--- a/Shared/UiPath.Shared.Activities/AsyncTaskNativeImplementation.cs
+++ b/Shared/UiPath.Shared.Activities/AsyncTaskNativeImplementation.cs
@@ -89,8 +89,7 @@ namespace UiPath.Shared.Activities
 
         public void BookmarkResumptionCallback(NativeActivityContext context, object value)
         {
-            var ex = value as Exception;
-            if (ex != null)
+            if (value is Exception ex)
             {
                 throw new InvalidOperationException(ex.Message, ex);
             }


### PR DESCRIPTION
This addresses an issue where any activity that inherits AsyncTaskCodeActivity would fail if executed in a loop. The AsyncTaskCodeActivity would previously dispose its CancellationTokenSource on EndExecute(). Now it still does that but it creates a new CancellationTokenSource on BeginExecute().