### PR TITLE
Google Spreadsheet Write range: change InputValueOption from RAW to U…

### DIFF
--- a/Google Spreadsheet/GoogleSpreadsheet.Activities/WriteRange.cs
+++ b/Google Spreadsheet/GoogleSpreadsheet.Activities/WriteRange.cs
@@ -55,7 +55,9 @@ namespace GoogleSpreadsheet.Activities
                 
                 SpreadsheetsResource.ValuesResource.UpdateRequest request =
                    sheetService.Spreadsheets.Values.Update(requestBody, SpreadsheetId, cellToPassToService);
-                request.ValueInputOption = SpreadsheetsResource.ValuesResource.UpdateRequest.ValueInputOptionEnum.RAW;
+
+                //request.ValueInputOption = SpreadsheetsResource.ValuesResource.UpdateRequest.ValueInputOptionEnum.RAW;
+                request.ValueInputOption = SpreadsheetsResource.ValuesResource.UpdateRequest.ValueInputOptionEnum.USERENTERED;
 
                 var response = request.Execute();
                 


### PR DESCRIPTION
Issue Description: In the spreadsheets the numeric values or dates are written as strings with a leading apostrophe. The input should be parsed exactly as if it were entered into the Google Sheets UI  so "Mar 1 2016" should be a date. https://developers.google.com/sheets/api/guides/values.