### PR TITLE
added PrivateKeyAuthenticationMethod to SftpSession

### DIFF
--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.Designer.cs
@@ -19,7 +19,7 @@ namespace UiPath.FTP.Activities.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class UiPath_FTP_Activities {
@@ -84,6 +84,15 @@ namespace UiPath.FTP.Activities.Properties {
         internal static string ClientCertificatePath {
             get {
                 return ResourceManager.GetString("ClientCertificatePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Path to the Private key in PKCS #1 PEM format.
+        /// </summary>
+        internal static string ClientCertificatePathDesc {
+            get {
+                return ResourceManager.GetString("ClientCertificatePathDesc", resourceCulture);
             }
         }
         
@@ -201,6 +210,15 @@ namespace UiPath.FTP.Activities.Properties {
         internal static string LocalPath {
             get {
                 return ResourceManager.GetString("LocalPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No valid authentication method found: You need to supply either Private Key file (and optionally passphare) or Password.
+        /// </summary>
+        internal static string NoValidAuthenticationMethod {
+            get {
+                return ResourceManager.GetString("NoValidAuthenticationMethod", resourceCulture);
             }
         }
         

--- a/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
+++ b/Activities/FTP/UiPath.FTP.Activities/Properties/UiPath.FTP.Activities.resx
@@ -213,4 +213,10 @@
   <data name="SslProtocols" xml:space="preserve">
     <value>SSL protocols</value>
   </data>
+  <data name="ClientCertificatePathDesc" xml:space="preserve">
+    <value>Path to the Private key in PKCS #1 PEM format</value>
+  </data>
+  <data name="NoValidAuthenticationMethod" xml:space="preserve">
+    <value>No valid authentication method found: You need to supply either Private Key file (and optionally passphare) or Password</value>
+  </data>
 </root>

--- a/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
+++ b/Activities/FTP/UiPath.FTP.Activities/WithFtpSession.cs
@@ -57,6 +57,7 @@ namespace UiPath.FTP.Activities
 
         [LocalizedCategory(nameof(Resources.Security))]
         [LocalizedDisplayName(nameof(Resources.ClientCertificatePath))]
+        [LocalizedDescription(nameof(Resources.ClientCertificatePathDesc))]
         public InArgument<string> ClientCertificatePath { get; set; }
 
         [LocalizedCategory(nameof(Resources.Security))]
@@ -103,6 +104,11 @@ namespace UiPath.FTP.Activities
                 if (string.IsNullOrWhiteSpace(ftpConfiguration.Username))
                 {
                     throw new ArgumentNullException(Resources.EmptyUsernameException);
+                }
+
+                if (string.IsNullOrWhiteSpace(ftpConfiguration.Password) && string.IsNullOrWhiteSpace(ftpConfiguration.ClientCertificatePath))
+                {
+                    throw new ArgumentNullException(Resources.NoValidAuthenticationMethod);
                 }
             }
 

--- a/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.Designer.cs
+++ b/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.Designer.cs
@@ -95,5 +95,14 @@ namespace UiPath.FTP.Properties {
                 return ResourceManager.GetString("UnsupportedObjectTypeException", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported object type encountered..
+        /// </summary>
+        internal static string NoValidAuthenticationMethod {
+            get {
+                return ResourceManager.GetString("NoValidAuthenticationMethod", resourceCulture);
+            }
+        }
     }
 }

--- a/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.resx
+++ b/Activities/FTP/UiPath.FTP/Properties/UiPath.FTP.resx
@@ -129,4 +129,7 @@
   <data name="UnsupportedObjectTypeException" xml:space="preserve">
     <value>Unsupported object type encountered.</value>
   </data>
+  <data name="NoValidAuthenticationMethod" xml:space="preserve">
+    <value>No valid authentication method found: You need to supply either Private Key file (and optionally passphare) or Password</value>
+  </data>
 </root>


### PR DESCRIPTION
This is to fix an error with SFTP session when the authentication has to be done via RSA key, not the password. Current code just ignored the existence of CertificatePath argument, always trying to connect using password and causing an error "`String reference not set to an instance of a String, parameter name s`" from SSH.NET lib if password was not supplied.
Also added a description to CertificatePath argument suggesting that the valid format for the key is PEM PCKS#1