### PR TITLE
Add null handling for parameters

### DIFF
--- a/Activities/Database/UiPath.Database/DatabaseConnection.cs
+++ b/Activities/Database/UiPath.Database/DatabaseConnection.cs
@@ -134,7 +134,8 @@ namespace UiPath.Database
                 {
                     dbParameter.Size = -1;
                 }
-                dbParameter.Value = param.Value.Item1;
+
+                dbParameter.Value = param.Value.Item1 ?? DBNull.Value;
                 _command.Parameters.Add(dbParameter);
             }
         }


### PR DESCRIPTION
From
https://docs.microsoft.com/en-us/dotnet/api/system.data.common.dbparameter.value

> When you send a null parameter value to the server, you must specify
DBNull, not null. The null value in the system is an empty object that
has no value. DBNull is used to represent null values.

Fixes #63

For non-object types, the parameter type in the Activity parameter
colleciton must be `Nullable<T>` not `T`. Eg. `Nullable<Int32>` for an
Int32 parameter. Value should be `Nothing`.

The system is still imperfect with regard to types as we let the
framework deduce the type from value, which does not work correctly with
`DbNull.Value` (will send `NVARCHAR(4000)` fro SQL for example). A
different fix is needed to address the type system, make the DbParamater
type explicit from the Activity Parameters dictionary declared type.