### PR TITLE
OSAC 60 - added patch version and revision number

### DIFF
--- a/Activities/.pipelines/jobs/ci.yml
+++ b/Activities/.pipelines/jobs/ci.yml
@@ -14,6 +14,8 @@ parameters:
   testList: []
   versionReference: ""
   versionNumber: "1.0.0"
+  versionSuffix: "-alpha1"
+
 
 jobs:
 - job: CI_Community_Activities_${{ replace(replace(parameters.BuildProject, '/', '_'), '.', '_') }}
@@ -31,6 +33,7 @@ jobs:
       rootPath:             ${{ parameters.rootPath }}
       versionReference:     ${{ parameters.versionReference }}
       versionNumber:        ${{ parameters.versionNumber }}
+      versionSuffix:        ${{ parameters.versionSuffix }}
 
   - template: "../steps/build.yml"
     parameters:
@@ -41,6 +44,8 @@ jobs:
       restoreDependencies:  ${{ parameters.restoreDependencies }}
       rootPath:             ${{ parameters.rootPath }}
       packagesDirectory:    ${{ parameters.packagesDirectory }}
+      versionNumber:        ${{ parameters.versionNumber }}
+      versionSuffix:        ${{ parameters.versionSuffix }}
 
   - template: "../steps/test.yml"
     parameters:
@@ -55,5 +60,5 @@ jobs:
       BuildProject:       ${{ parameters.BuildProject }}
       BuildConfiguration: ${{ parameters.BuildConfiguration }}
       rootPath:           ${{ parameters.rootPath }}
-
-
+      versionNumber:        ${{ parameters.versionNumber }}
+      versionSuffix:        ${{ parameters.versionSuffix }}

--- a/Activities/.pipelines/steps/build.yml
+++ b/Activities/.pipelines/steps/build.yml
@@ -8,6 +8,8 @@ parameters:
   restoreDependencies: []
   rootPath: $(Build.SourcesDirectory)
   packagesDirectory: ""
+  versionNumber: ""
+  versionSuffix: ""
 
 steps:
 - ${{ each depend in parameters.restoreDependencies }}:
@@ -33,3 +35,4 @@ steps:
     solution:       ${{ format('{0}{1}', parameters.rootPath, parameters.BuildProject) }}
     platform:       ${{ parameters.BuildPlatform }}
     configuration:  ${{ parameters.BuildConfiguration }}
+    msbuildArgs:    '/p:Version=$(versionNumber)$(versionSuffix)'

--- a/Activities/.pipelines/steps/package.yml
+++ b/Activities/.pipelines/steps/package.yml
@@ -22,11 +22,15 @@ steps:
   inputs:
     command: "pack"
     packagesToPack: "$(PackagesToPack)"
-    versioningScheme: "byBuildNumber"
+    versioningScheme: "off"
     includeSymbols: "true"
     outputDir: "$(Build.ArtifactStagingDirectory)"
     configurationToPack: ${{ parameters.BuildConfiguration }}
     includeReferencedProjects: "true"
+    ${{ if eq(parameters.versionSuffix, '') }}:
+     buildProperties: 'ver=${{ parameters.versionNumber }}'
+    ${{ if ne(parameters.versionSuffix, '') }}:
+     buildProperties: 'ver=${{ parameters.versionNumber }}-${{ parameters.versionSuffix }}'
 
 - task: PublishBuildArtifacts@1
   displayName: "Publish symbols"

--- a/Activities/.pipelines/steps/pre_build.yml
+++ b/Activities/.pipelines/steps/pre_build.yml
@@ -1,18 +1,27 @@
 parameters:
+  BuildConfiguration: "Release"
+  BuildPlatform: "AnyCPU"
   NuGetVersionSpec: "4.3.0"
   rootPath: ""
   versionReference: ""
   versionNumber: ""
+  versionSuffix: ""
 
 steps:
 - task: PowerShell@1
   displayName: "Set Build Version"
   inputs:
     scriptType: "inlineScript"
-    inlineScript: |
-      $version = "${{ parameters.versionNumber }}"  
-      Write-Host "$version" 
-      Write-Host "##vso[build.updatebuildnumber]$version"
+    ${{ if eq(parameters.versionSuffix, '') }}:
+     inlineScript: |
+       $version = "${{ parameters.versionNumber }}" 
+       Write-Host "$version" 
+       Write-Host "##vso[build.updatebuildnumber]$version"
+    ${{ if ne(parameters.versionSuffix, '') }}:
+     inlineScript: |
+       $version = "${{ parameters.versionNumber }}-${{ parameters.versionSuffix }}" 
+       Write-Host "$version" 
+       Write-Host "##vso[build.updatebuildnumber]$version"
 
 - task: NuGetToolInstaller@1
   displayName: "Use NuGet ${{ parameters.NuGetVersionSpec }}"
@@ -20,7 +29,10 @@ steps:
     versionSpec: ${{ parameters.NuGetVersionSpec }}
 
 - task: Assembly-Info-NetFramework@2
-  displayName: "Set Assembly version to ${{ parameters.versionNumber }}"
+  ${{ if eq(parameters.versionSuffix, '') }}:
+   displayName: "Set Assembly version to ${{ parameters.versionNumber }}"
+  ${{ if ne(parameters.versionSuffix, '') }}:
+   displayName: "Set Assembly version to ${{ parameters.versionNumber }}-${{ parameters.versionSuffix }}"
   inputs:
     Path: "${{ parameters.rootPath }}" 
     FileNames: |
@@ -34,6 +46,6 @@ steps:
     LogLevel: 'verbose'
     FailOnWarning: false
     DisableTelemetry: false
-    InformationalVersion: "${{ parameters.versionNumber }}"
+    InformationalVersion: "${{ parameters.versionNumber }}-${{ parameters.versionSuffix }}"
     FileVersionNumber: "${{ parameters.versionNumber }}" 
     VersionNumber:  "${{ parameters.versionNumber }}" 

--- a/Activities/Credentials/UiPath.Credentials.Activities/UiPath.Credentials.Activities.nuspec
+++ b/Activities/Credentials/UiPath.Credentials.Activities/UiPath.Credentials.Activities.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$title$</id>
-    <version>$version$</version>
+    <version>$ver$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/Activities/Credentials/azure-pipelines.yaml
+++ b/Activities/Credentials/azure-pipelines.yaml
@@ -13,8 +13,11 @@ trigger:
 variables:
   majorVersion: '1'
   minorVersion: '3'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  versionSuffix: 'alpha$(revision)' #this can be empty
+
 
 pr:
   branches:
@@ -38,4 +41,5 @@ jobs:
       rootPath: $(Build.SourcesDirectory)\Activities\Credentials\
       packagesDirectory: $(Build.SourcesDirectory)\Activities\packages\
       versionReference: "UiPath.Credentials.Activities/Properties/AssemblyInfo.cs"
-      versionNumber: ${{ variables.packageVersion }}
+      versionNumber: ${{ variables.versionNumber }}
+      versionSuffix: ${{ variables.versionSuffix }}

--- a/Activities/Database/UiPath.Database.Activities.Design/UiPath.Database.Activities.Design.nuspec
+++ b/Activities/Database/UiPath.Database.Activities.Design/UiPath.Database.Activities.Design.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$title$</id>
-    <version>$version$</version>
+    <version>$ver$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/Activities/Database/azure-pipelines.yaml
+++ b/Activities/Database/azure-pipelines.yaml
@@ -13,8 +13,10 @@ trigger:
 variables:
   majorVersion: '1'
   minorVersion: '4'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  versionSuffix: 'alpha$(revision)' #this can be empty
 
 pr:
   branches:
@@ -43,4 +45,5 @@ jobs:
       testList: 
         - "UiPath.Database.Tests/UiPath.Database.Tests.csproj"
       versionReference: "DatabaseAssemblyVersion.cs"
-      versionNumber: ${{ variables.packageVersion }}
+      versionNumber: ${{ variables.versionNumber }}
+      versionSuffix: ${{ variables.versionSuffix }}

--- a/Activities/FTP/UiPath.FTP.Activities.Design/UiPath.FTP.Activities.Design.nuspec
+++ b/Activities/FTP/UiPath.FTP.Activities.Design/UiPath.FTP.Activities.Design.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$title$</id>
-    <version>$version$</version>
+    <version>$ver$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/Activities/FTP/azure-pipelines.yaml
+++ b/Activities/FTP/azure-pipelines.yaml
@@ -13,8 +13,10 @@ trigger:
 variables:
   majorVersion: '2'
   minorVersion: '2'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  versionSuffix: 'alpha$(revision)' #this can be empty
 
 pr:
   branches:
@@ -41,4 +43,5 @@ jobs:
         - "UiPath.FTP.Activities/UiPath.FTP.Activities.csproj"
         - "UiPath.FTP/UiPath.FTP.csproj"      
       versionReference: "FTPAssemblyInfo.cs"
-      versionNumber: ${{ variables.packageVersion }}
+      versionNumber: ${{ variables.versionNumber }}
+      versionSuffix: ${{ variables.versionSuffix }}

--- a/Activities/GoogleSpreadsheet/GoogleSpreadsheet.Activities.Design/GoogleSpreadsheet.Activities.Design.nuspec
+++ b/Activities/GoogleSpreadsheet/GoogleSpreadsheet.Activities.Design/GoogleSpreadsheet.Activities.Design.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>GoogleSpreadsheet.Activities</id>
-    <version>$version$</version>
+    <version>$ver$</version>
     <title>GoogleSpreadsheet.Activities</title>
     <authors>bogdan.popescu</authors>
     <owners>bogdan.popescu</owners>

--- a/Activities/GoogleSpreadsheet/azure-pipelines.yaml
+++ b/Activities/GoogleSpreadsheet/azure-pipelines.yaml
@@ -13,8 +13,11 @@ trigger:
 variables:
   majorVersion: '1'
   minorVersion: '2'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  versionSuffix: 'alpha$(revision)' #this can be empty
+
 
 pr:
   branches:
@@ -43,4 +46,5 @@ jobs:
       testList: 
         - "GoogleSpreadsheet.Activities.UnitTest/GoogleSpreadsheet.Activities.UnitTest.csproj"      
       versionReference: "GoogleSpreadsheetVersion.cs"
-      versionNumber: ${{ variables.packageVersion }}
+      versionNumber: ${{ variables.versionNumber }}
+      versionSuffix: ${{ variables.versionSuffix }}

--- a/Activities/Java/UiPath.Java.Activities.Design/UiPath.Java.Activities.Design.nuspec
+++ b/Activities/Java/UiPath.Java.Activities.Design/UiPath.Java.Activities.Design.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$title$</id>
-    <version>$version$</version>
+    <version>$ver$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/Activities/Java/azure-pipelines.yaml
+++ b/Activities/Java/azure-pipelines.yaml
@@ -13,8 +13,11 @@ trigger:
 variables:
   majorVersion: '1'
   minorVersion: '2'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  versionSuffix: 'alpha$(revision)' #this can be empty
+
 
 pr:
   branches:
@@ -43,5 +46,6 @@ jobs:
       testList: 
         - "UiPath.Java.Test/UiPath.Java.Test.csproj"
       versionReference: "JavaPackageVersion.cs"
-      versionNumber: ${{ variables.packageVersion }}
+      versionNumber: ${{ variables.versionNumber }}
+      versionSuffix: ${{ variables.versionSuffix }}
 

--- a/Activities/Python/UiPath.Python.Activities.Design/UiPath.Python.Activities.Design.nuspec
+++ b/Activities/Python/UiPath.Python.Activities.Design/UiPath.Python.Activities.Design.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$title$</id>
-    <version>$version$</version>
+    <version>$ver$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/Activities/Python/azure-pipelines.yml
+++ b/Activities/Python/azure-pipelines.yml
@@ -13,8 +13,11 @@ trigger:
 variables:
   majorVersion: '1'
   minorVersion: '3'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  versionSuffix: 'alpha$(revision)' #this can be empty
+
 
 pr:
   branches:
@@ -43,4 +46,5 @@ jobs:
       testList: 
         - "UiPath.Python.Tests/UiPath.Python.Tests.csproj"
       versionReference: "PythonPackageVersion.cs"
-      versionNumber: ${{ variables.packageVersion }}
+      versionNumber: ${{ variables.versionNumber }}
+      versionSuffix: ${{ variables.versionSuffix }}

--- a/Activities/Twilio/UiPath.Twilio.Activities/UiPath.Twilio.Activities.nuspec
+++ b/Activities/Twilio/UiPath.Twilio.Activities/UiPath.Twilio.Activities.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>$title$</id>
-    <version>$version$</version>
+    <version>$ver$</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>$author$</owners>

--- a/Activities/Twilio/azure-pipelines.yaml
+++ b/Activities/Twilio/azure-pipelines.yaml
@@ -13,8 +13,10 @@ trigger:
 variables:
   majorVersion: '1'
   minorVersion: '1'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  versionSuffix: 'alpha$(revision)' #this can be empty
 
 pr:
   branches:
@@ -38,4 +40,5 @@ jobs:
       rootPath: $(Build.SourcesDirectory)\Activities\Twilio\
       packagesDirectory: $(Build.SourcesDirectory)\Activities\packages\
       versionReference: "UiPath.Twilio.Activitie/Properties/AssemblyInfo.cs"
-      versionNumber: ${{ variables.packageVersion }}
+      versionNumber: ${{ variables.versionNumber }}
+      versionSuffix: ${{ variables.versionSuffix }}


### PR DESCRIPTION
+ Description
All package releases should follow a semantic versioning schema (X.Y.Z = Major.Minor.Patch) with revision number (for internal test channels).
Major, Minor and Patch are static versions in the corresponding YML file.
Revision is calculated in DevOps using YML counter
Calculated version number is then overwritten in AssemblyInfo.cs files (for DLL version consistency).
To bump Major/Minor/Patch, edit corresponding YML build file for each package.
+ How to test
[Pipeline twsoftr.Community.Activities](https://dev.azure.com/uipath/Community/_build?definitionId=1411&_a=summary)
+ Jira
[OSAC-60](https://uipath.atlassian.net/browse/OSAC-60)
+ Label:
24S