### PR TITLE
modified version numbers according to OSAC-60

### DIFF
--- a/Activities/Credentials/azure-pipelines.yaml
+++ b/Activities/Credentials/azure-pipelines.yaml
@@ -14,9 +14,13 @@ variables:
   majorVersion: '1'
   minorVersion: '3'
   patchVersion: '0'
-  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  versionSuffix: 'alpha$(revision)' #this can be empty
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 
 pr:

--- a/Activities/Credentials/azure-pipelines.yaml
+++ b/Activities/Credentials/azure-pipelines.yaml
@@ -15,10 +15,10 @@ variables:
   minorVersion: '3'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 

--- a/Activities/Cryptography/azure-pipelines.yaml
+++ b/Activities/Cryptography/azure-pipelines.yaml
@@ -12,8 +12,14 @@ trigger:
 variables:
   majorVersion: '1'
   minorVersion: '2'
-  revision: $[counter(variables['minorVersion'], 1)] #this will get reset when minor gets bumped.
-  packageVersion: '$(majorVersion).$(minorVersion).$(revision)'
+  patchVersion: '0'
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
+  versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 pr:
   branches:

--- a/Activities/Cryptography/azure-pipelines.yaml
+++ b/Activities/Cryptography/azure-pipelines.yaml
@@ -14,10 +14,10 @@ variables:
   minorVersion: '2'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 

--- a/Activities/Database/azure-pipelines.yaml
+++ b/Activities/Database/azure-pipelines.yaml
@@ -15,10 +15,10 @@ variables:
   minorVersion: '4'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 

--- a/Activities/Database/azure-pipelines.yaml
+++ b/Activities/Database/azure-pipelines.yaml
@@ -14,9 +14,13 @@ variables:
   majorVersion: '1'
   minorVersion: '4'
   patchVersion: '0'
-  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  versionSuffix: 'alpha$(revision)' #this can be empty
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 pr:
   branches:

--- a/Activities/FTP/azure-pipelines.yaml
+++ b/Activities/FTP/azure-pipelines.yaml
@@ -15,10 +15,10 @@ variables:
   minorVersion: '2'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 

--- a/Activities/FTP/azure-pipelines.yaml
+++ b/Activities/FTP/azure-pipelines.yaml
@@ -14,9 +14,13 @@ variables:
   majorVersion: '2'
   minorVersion: '2'
   patchVersion: '0'
-  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  versionSuffix: 'alpha$(revision)' #this can be empty
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 pr:
   branches:

--- a/Activities/GoogleSpreadsheet/azure-pipelines.yaml
+++ b/Activities/GoogleSpreadsheet/azure-pipelines.yaml
@@ -14,9 +14,13 @@ variables:
   majorVersion: '1'
   minorVersion: '2'
   patchVersion: '0'
-  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  versionSuffix: 'alpha$(revision)' #this can be empty
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 
 pr:

--- a/Activities/GoogleSpreadsheet/azure-pipelines.yaml
+++ b/Activities/GoogleSpreadsheet/azure-pipelines.yaml
@@ -15,10 +15,10 @@ variables:
   minorVersion: '2'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 

--- a/Activities/Java/azure-pipelines.yaml
+++ b/Activities/Java/azure-pipelines.yaml
@@ -14,9 +14,13 @@ variables:
   majorVersion: '1'
   minorVersion: '2'
   patchVersion: '0'
-  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  versionSuffix: 'alpha$(revision)' #this can be empty
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 
 pr:

--- a/Activities/Java/azure-pipelines.yaml
+++ b/Activities/Java/azure-pipelines.yaml
@@ -15,10 +15,10 @@ variables:
   minorVersion: '2'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 

--- a/Activities/Python/azure-pipelines.yml
+++ b/Activities/Python/azure-pipelines.yml
@@ -14,9 +14,13 @@ variables:
   majorVersion: '1'
   minorVersion: '3'
   patchVersion: '0'
-  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  versionSuffix: 'alpha$(revision)' #this can be empty
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 
 pr:

--- a/Activities/Python/azure-pipelines.yml
+++ b/Activities/Python/azure-pipelines.yml
@@ -15,10 +15,10 @@ variables:
   minorVersion: '3'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 

--- a/Activities/Twilio/azure-pipelines.yaml
+++ b/Activities/Twilio/azure-pipelines.yaml
@@ -14,9 +14,13 @@ variables:
   majorVersion: '1'
   minorVersion: '1'
   patchVersion: '0'
-  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when patch gets bumped.
+  revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
+  versionSuffix: ''
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  versionSuffix: 'alpha$(revision)' #this can be empty
+  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
+   versionSuffix: 'alpha.$(revision)'
+  ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
+   versionSuffix: 'beta.$(revision)'
 
 pr:
   branches:

--- a/Activities/Twilio/azure-pipelines.yaml
+++ b/Activities/Twilio/azure-pipelines.yaml
@@ -15,10 +15,10 @@ variables:
   minorVersion: '1'
   patchVersion: '0'
   revision: $[counter(variables['patchVersion'], 1)] #this will get reset when minor gets bumped.
-  versionSuffix: ''
+  versionSuffix: 'alpha.$(revision)'
   versionNumber: '$(majorVersion).$(minorVersion).$(patchVersion)'
-  ${{ if eq(variables['Build.SourceBranchName'], 'develop') }}:
-   versionSuffix: 'alpha.$(revision)'
+  ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+   versionSuffix: ''
   ${{ if contains(variables['Build.SourceBranchName'], 'release') }}:
    versionSuffix: 'beta.$(revision)'
 


### PR DESCRIPTION
+ Description
All package releases should follow a semantic versioning schema (X.Y.Z = Major.Minor.Patch) with revision number (for internal test channels).
Major, Minor and Patch are static versions in the corresponding YML file.
Revision is calculated in DevOps using YML counter
Calculated version number is then overwritten in AssemblyInfo.cs files (for DLL version consistency).
To bump Major/Minor/Patch, edit corresponding YML build file for each package.
+ How to test
[Pipeline twsoftr.Community.Activities](https://dev.azure.com/uipath/Community/_build?definitionId=1411&_a=summary)
+ Jira
[OSAC-60](https://uipath.atlassian.net/browse/OSAC-60)
+ Label:
24S